### PR TITLE
docs: fix Sim2Real remote key hint (s → start)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Please read [official document](https://support.unitree.com/home/en/G1_developer
    ```
 3. The state machine matches Sim2Sim but with `physical remote controller` input
    - Zero torque
-   - (Press `S`) → move to default pose
+   - (Press `start`) → move to default pose
    - Place robot on the ground
    - (Press `A`) → run the active policy
    - See [Motion Switching](#motion-switching) to replay different motions.


### PR DESCRIPTION
The README incorrectly tells users to “Press s” when running Sim2Real on the physical G1, but the robot only ships with a game-pad that has no s key.
This PR replaces the keyboard letter with the actual button name (start) and keeps the remaining mapping consistent.